### PR TITLE
DEVO-930 Updates packages to generate a new harbor image

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -10,17 +10,17 @@ ARG SECRET_KEY_BASE
 ARG RAILS_MASTER_KEY
 
 RUN apk add -U --no-cache \
-      bash=5.2.15-r5 \
-      libc6-compat=1.2.4-r2 \
+      bash=5.2.21-r0 \
+      gcompat=1.1.0-r4 \
       tzdata=2023c-r1 \
-      postgresql14-client=14.9-r0 \
-      libxslt=1.1.38-r0 && \
+      postgresql14-client=14.10-r0 \
+      libxslt=1.1.39-r0 && \
     apk add -U --no-cache --virtual build-dependencies \
       build-base=0.5-r3 \
-      git=2.40.1-r0 \
-      postgresql14-dev=14.9-r0 \
-      libxslt-dev=1.1.38-r0 \
-      nodejs=18.18.2-r0 \
+      git=2.43.0-r0 \
+      postgresql14-dev=14.10-r0 \
+      libxslt-dev=1.1.39-r0 \
+      nodejs=20.10.0-r1 \
       yarn=1.22.19-r0 && \
     gem install bundler:2.3.3 && \
     bundle config build.nokogiri --use-system-libraries && \


### PR DESCRIPTION
The latest alpine version removes libc6-compat in favor of gcompat.