### PR TITLE
Waive CVE-2024-49761 rexml version 3.3.6

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -13,12 +13,12 @@ RUN apk add -U --no-cache \
       bash=5.2.26-r0 \
       gcompat=1.1.0-r4 \
       tzdata=2024b-r0 \
-      postgresql16-client=16.3-r0 \
+      postgresql16-client=16.4-r0 \
       libxslt=1.1.39-r1 && \
     apk add -U --no-cache --virtual build-dependencies \
       build-base=0.5-r3 \
       git=2.45.2-r0 \
-      postgresql16-dev=16.3-r0 \
+      postgresql16-dev=16.4-r0 \
       libxslt-dev=1.1.39-r1 \
       nodejs=20.15.1-r0 \
       yarn=1.22.22-r0 && \

--- a/Documentation/Ruby-CVE-2024-49761
+++ b/Documentation/Ruby-CVE-2024-49761
@@ -1,0 +1,1 @@
+Gemfile.lock shows rexml is at version 3.3.9, however we suspect rexml is pinned to 3.3.6 in another Gem. We will wait until all gems dependent on rexml are updated

--- a/Documentation/essential_packages.txt
+++ b/Documentation/essential_packages.txt
@@ -1,1 +1,2 @@
 bootstrap
+rexml


### PR DESCRIPTION
- Waives rexml until gems update to rexml 3.3.9
- Update package dependencies