### PR TITLE
CVE-2025-27219 and 27220 - Add cgi to Gemfile and pin version 0.4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem "turbolinks", "~> 5"
 gem "uglifier", ">= 1.3.0"
 gem "warden"
 gem "nokogiri", "~> 1.18.6"
+gem "cgi", "~> 0.4.2"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.4.2)
     childprocess (5.1.0)
       logger (~> 1.5)
     choice (0.2.0)
@@ -460,6 +461,7 @@ DEPENDENCIES
   brakeman
   byebug
   capybara (~> 3)
+  cgi (~> 0.4.2)
   concurrent-ruby (= 1.3.4)
   cssbundling-rails
   execjs


### PR DESCRIPTION
cgi gem may not get updated to version that addresses CVE-2025-27219 and 27220. This specifies the gem and its version. 